### PR TITLE
Fix config.ini password on Python 3

### DIFF
--- a/roomba/password.py
+++ b/roomba/password.py
@@ -156,16 +156,18 @@ class Password(object):
                       'instructions and try again.' % len(data))
                 return False
             else:
+                # Convert password to str
+                password = str(data[7:].decode())
                 print("blid is: %s" % blid)
-                print('Password=> %s <= Yes, all this string.' % str(data[7:]))
+                print('Password=> %s <= Yes, all this string.' % password)
                 print('Use these credentials in roomba.py')
 
                 Config = configparser.ConfigParser()
                 Config.add_section(addr)
-                Config.set(addr,'blid',blid)
-                Config.set(addr,'password',str(data[7:]))
+                Config.set(addr,'blid', blid)
+                Config.set(addr,'password', password)
                 Config.set(addr,'data', pformat(parsedMsg))
-                #write config file
+                # write config file
                 with open(self.file, 'w') as cfgfile:
                     Config.write(cfgfile)
         return True


### PR DESCRIPTION
- Fix passwords in `config.ini` when retrieving credentials with `roomba-getpassword`

This convert the password to `str`, previously the config contained passwords like `b'XSDUdwd213'` (notice the leading `b` and the single quotes)