### PR TITLE
Update installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ First you need python 2.7 *or* python 3.5/3.6 installed (thanks to pschmitt for 
 
 install via pip (this will take of dependencies as well):
 ```bash
-pip install https://github.com/NickWaterton/Roomba980-Python.git
+pip install git+https://github.com/NickWaterton/Roomba980-Python.git
 ```
 
 Alternatively you may get going by cloning this repository:


### PR DESCRIPTION
The current installation instructions result in   

```bash
Cannot unpack file /tmp/pip-_R4VJa-unpack/Roomba980-Python.git (downloaded from /tmp/pip-dCmR9k-build, content-type: text/html; charset=utf-8); cannot detect archive format
Cannot determine archive format of /tmp/pip-dCmR9k-build
```

Adding git+ in front of the URL, however, solves the problem.