### PR TITLE
Fix missing comma in roomba.py

### DIFF
--- a/roomba/roomba.py
+++ b/roomba/roomba.py
@@ -156,7 +156,7 @@ class Roomba(object):
         15: "Reboot required",
         16: "Bumped unexpectedly",
         17: "Path blocked",
-        18: "Docking issue"
+        18: "Docking issue",
         19: "Undocking issue",
         20: "Docking issue",
         21: "Navigation problem",


### PR DESCRIPTION
Syntax errors when I tried to use getpasswd.py... just a missing comma so I figured I'd pass up the fix.