### PR TITLE
Fix compatibility with Pillow v7

### DIFF
--- a/roomba/roomba.py
+++ b/roomba/roomba.py
@@ -554,7 +554,7 @@ class Roomba(object):
         if not HAVE_PIL: #can't draw a map without PIL!
             return False
 
-        if Image.PILLOW_VERSION < "4.1.1":
+        if hasattr(Image, 'PILLOW_VERSION') and Image.PILLOW_VERSION < "4.1.1":
             print("WARNING: PIL version is %s, this is not the latest! you "
                   "can get bad memory leaks with old versions of PIL"
                   % Image.PILLOW_VERSION)


### PR DESCRIPTION
Pillow v7 dropped the `PILLOW_VERSION` constant

https://pillow.readthedocs.io/en/stable/releasenotes/7.0.0.html