### PR TITLE
Adding the "evac" state which is entered into when emptying the bin.

### DIFF
--- a/roomba/roomba.py
+++ b/roomba/roomba.py
@@ -119,6 +119,7 @@ class Roomba(object):
               "cancelled": "Cancelled",
               "stop": "Stopped",
               "pause": "Paused",
+              "evac" : "Emptying",
               "hmPostMsn": "End Mission",
               "":  None}
 
@@ -1196,6 +1197,11 @@ class Roomba(object):
             self.display_text = "Completed: " + \
                 time.strftime("%a %b %d %H:%M:%S")
             self.log.info("MAP: end of mission")
+
+        elif self.current_state == self.states["evac"]:
+            self.display_text = "Emptying Bin: " + \
+                time.strftime("%a %b %d %H:%M:%S")
+            self.log.info("MAP: emptying bin")
 
         elif self.current_state == self.states["dockend"]:
             self.log.info("MAP: mission completed: ignoring new co-ords in "


### PR DESCRIPTION
Tested on i7+
Bin can be emptied during a job, at the end of a job, or as a separate command. This commit fixes the issue where an unknown state is entered to, causing the program to crash.