### PR TITLE
Fix deprecated reference to ABC collections alias

### DIFF
--- a/roomba/roomba.py
+++ b/roomba/roomba.py
@@ -39,7 +39,7 @@ __version__ = "2.0.0i"
 import asyncio
 from ast import literal_eval
 #from collections import OrderedDict, Mapping
-from collections import Mapping
+from collections.abc import Mapping
 from password import Password
 import datetime
 import json


### PR DESCRIPTION
Hi. I just downloaded the project and tried it on Python 3.10 and ran into an import error. Apparently, the collections.Mapping is an alias that was kept for Python 2.X backwards compatibility and is removed in 3.10 (see https://docs.python.org/3/whatsnew/3.10.html#removed). 

According to the docs, it was deprecated in 3.3, so the change should be safe for 3.6+.