### PR TITLE
Fix get cloud password

### DIFF
--- a/roomba/getcloudpassword.py
+++ b/roomba/getcloudpassword.py
@@ -28,7 +28,7 @@ class awsRequest:
         self.secret_key = secret_key
         self.session_token = session_token
         self.service = service
-            
+
     def sign(self, key, msg):
         return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
 
@@ -99,11 +99,6 @@ class irobotAuth:
 
         response = r.json()
 
-        data = {"timestamp": int(time.time()),
-                "nonce": "%d_%d" % (int(time.time()), random.randint(0, 2147483647)),
-                "oauth_token": response['sessionInfo']['sessionToken'],
-                "targetEnv": "mobile"}
-
         uid = response['UID']
         uidSig = response['UIDSignature']
         sigTime = response['signatureTimestamp']
@@ -151,7 +146,7 @@ def main():
     LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
     LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
     logging.basicConfig(format=LOG_FORMAT, datefmt=LOG_DATE_FORMAT, level=loglevel)
-    
+
     #-------- Command Line -----------------
     parser = argparse.ArgumentParser(
         description='Get password and map data from iRobot aws cloud service')


### PR DESCRIPTION
Fix error:

```python
$ python3 ./password.py "login" "password"
2022-01-01 11:39:11 INFO [Roomba.Password] Using Password version 2.1
2022-01-01 11:39:11 INFO [Roomba.Password] reading/writing info from config file ./config.ini
2022-01-01 11:39:11 INFO [Roomba.Password] waiting on port: 5678 for data
2022-01-01 11:39:21 INFO [Roomba.Password] Getting Roomba information from iRobot aws cloud...
2022-01-01 11:39:21 DEBUG [urllib3.connectionpool] Starting new HTTPS connection (1): disc-prod.iot.irobotapi.com:443
2022-01-01 11:39:36 DEBUG [urllib3.connectionpool] https://disc-prod.iot.irobotapi.com:443 "GET /v1/discover/endpoints?country_code=US HTTP/1.1" 200 1855
2022-01-01 11:39:36 DEBUG [urllib3.connectionpool] Starting new HTTPS connection (1): accounts.us1.gigya.com:443
2022-01-01 11:39:40 DEBUG [urllib3.connectionpool] https://accounts.us1.gigya.com:443 "POST /accounts.login HTTP/1.1" 200 772
Traceback (most recent call last):
  File "./password.py", line 293, in <module>
    main()
  File "./password.py", line 290, in main
    get_passwd.get_password()
  File "./password.py", line 119, in get_password
    iRobot.login()
  File "/mnt/c/Users/User/Roomba980-Python/roomba/getcloudpassword.py", line 104, in login
    "oauth_token": response['sessionInfo']['sessionToken'],
KeyError: 'sessionToken'

````