### PR TITLE
More robust handling of password null-termination and empty passwords

### DIFF
--- a/roomba/password.py
+++ b/roomba/password.py
@@ -163,7 +163,10 @@ class Password(object):
                                     'Follow the instructions and try again.'.format(robotname, addr, len(data)))
                     continue
                 # Convert password to str
-                password = str(data[7:].decode().rstrip('\x00')) #for i7 - has null termination
+                password = data[7:]
+                if b'\x00' in password:
+                    password = password[:password.find(b'\x00')] #for i7 - has null termination
+                password = str(password.decode())
             self.log.info("blid is: {}".format(blid))
             self.log.info('Password=> {} <= Yes, all this string.'.format(password))
             self.log.info('Use these credentials in roomba.py')

--- a/roomba/roomba.py
+++ b/roomba/roomba.py
@@ -451,7 +451,7 @@ class Roomba(object):
         self.loop.create_task(self.process_command_q())
         self.update = self.loop.create_task(self.periodic_update())
 
-        if not all([self.address, self.blid, self.password]):
+        if not all(field is not None for field in [self.address, self.blid, self.password]):
             if not self.configure_roomba():
                 self.log.critical('Could not configure Roomba')
         else:
@@ -541,7 +541,7 @@ class Roomba(object):
         '''
         Connect to Roomba MQTT server
         '''
-        if not all([self.address, self.blid, self.password]):
+        if not all(field is not None for field in [self.address, self.blid, self.password]):
             self.log.critical("Invalid address, blid, or password! All these "
                               "must be specified!")
             return False

--- a/roomba/roomba_direct.py
+++ b/roomba/roomba_direct.py
@@ -379,7 +379,7 @@ def main():
     group = None
     options = vars(arg) #use args as dict
 
-    if arg.blid is None or arg.password is None:
+    if arg.blid is None and arg.password is None:
         get_passwd = Password(arg.roomba_ip,file=arg.configfile)
         roombas = get_passwd.get_roombas()
     else:


### PR DESCRIPTION
I experimented with my Roomba i3, attempting to initialize it without using the official iRobot app. The first thing I tried is connecting to it using the Roomba's SoftAP used for initial provisioning - and it kind of works, but it turned out the initial password was empty.

The response to the magic packet in this case was:
```
00000000  f0 2e ef cc 3b 29 00 00  00 00 00 b4 43 cb 77 18  |....;)......C.w.|
00000010  4b 8c 77 4c 4b 8c 77 10  6e ba 77 30 6c b6 77 05  |K.wLK.w.n.w0l.w.|
00000020  00 00 00 06 85 f6 64 50  26 a8 55 34 00 5c 55 10  |......dP&.U4.\U.|
00000030
```
There are a couple of null bytes starting at offset 7, followed by something that looks like garbage data. If this is supposed to be null-terminated, then the _first_ null byte should be taken into account instead of just `rstrip()`ing the data. Otherwise the app fails with an `UnicodeDecodeError`.

While connecting via the SoftAP interface may not be very useful, this might additionally help in case of a irregularly short password.

EDIT: In the second commit, I also made the `address`, `blid` and `password` field validation less aggressive, so that connection via that SoftAP can be made. It's not very useful, as the network disappears after the first command - but you _can_ order the robot to start cleaning while connected to its SoftAP network. The password is empty in that configuration, though, so the app in its current state did not allow that.