### PR TITLE
initwifi.py script for doing the initial provisioning

### DIFF
--- a/roomba/initwifi.py
+++ b/roomba/initwifi.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import asyncio
+import binascii
+import json
+import logging
+import time
+
+from roomba import Password, Roomba
+
+
+class InitWifi(object):
+    def __init__(self,
+                 address='192.168.10.1',
+                 wifi_ssid=None,
+                 wifi_password=None,
+                 country=None,
+                 timezone=None,
+                 robot_name=None,
+                 sdisc_url=None,
+                 ntphosts=None,
+                 cloud_env=None):
+        self.address = address
+        self.wifi_ssid = wifi_ssid
+        self.wifi_password = wifi_password
+        self.country = country
+        self.timezone = timezone
+        self.robot_name = robot_name
+        self.sdisc_url = sdisc_url
+        self.ntphosts = ntphosts
+        self.cloud_env = cloud_env
+
+        self.log = logging.getLogger('Roomba.{}'.format(__class__.__name__))
+
+        if self.timezone is None:
+            try:
+                import tzlocal
+                self.timezone = str(tzlocal.get_localzone())
+            except ImportError:
+                self.log.warning('tzlocal module not present, cannot determine system timezone')
+                pass
+
+        if self.country is None:
+            try:
+                import pytz
+                for country_code in pytz.country_names:
+                    try:
+                        if self.timezone in pytz.country_timezones(country_code):
+                            self.country = country_code
+                            break
+                    except KeyError:
+                        continue
+            except ImportError:
+                self.log.warning('pytz module not present, cannot determine country code')
+                pass
+
+    def init_wifi(self):
+        get_passwd = Password(self.address, file=None)
+
+        self.log.info("Trying to discover robot at address {}".format(self.address))
+        roombas = get_passwd.receive_udp()
+        if len(roombas) == 0:
+            self.log.warning("No Roombas found on network, try again...")
+            return False
+
+        if len(roombas) > 1:
+            self.log.warning("More than one Roomba found. Please provide a specific IP address")
+            return False
+
+        addr, parsedMsg = next(iter(roombas.items()))
+        blid = parsedMsg.get('robotid', parsedMsg.get("hostname", "").split('-')[1])
+        fw_ver = int(parsedMsg.get("ver", "3"))
+        if fw_ver < 2:
+            self.log.info(
+                "Roombas at address: {} does not have the correct firmware version. Your version info is: {}".format(
+                    addr, json.dumps(parsedMsg, indent=2)))
+            return False
+
+        if self.wifi_ssid is None:
+            self.log.info("WiFi SSID not specified")
+            self.wifi_ssid = input("Type the SSID that the robot shall use: ")
+            if not self.wifi_ssid:
+                self.log.error("WiFi SSID not provided, aborting")
+                return False
+
+        if self.wifi_password is None:
+            self.log.info("WiFi password not specified")
+            self.wifi_password = input("Type the password that the robot shall use: ")
+            if self.wifi_password is None:
+                self.log.error("WiFi password not provided, aborting")
+                return False
+
+        if self.wifi_ssid is None or self.wifi_password is None:
+            self.log.critical("Invalid wifi_ssid or wifi_password! All these must be specified!")
+            return False
+
+        password = parsedMsg.get('password')
+        if password is None:
+            password = get_passwd.get_password_from_roomba(addr)
+        if not password:
+            self.log.info("No password set, attempting to generate and set a new one...")
+            time.sleep(1)
+            password = get_passwd.set_new_password_on_roomba(addr)
+            time.sleep(1)
+
+            if password is None or get_passwd.get_password_from_roomba(addr) != password:
+                self.log.error("Setting MQTT password failed")
+                return False
+
+        self.log.info("blid is: {}".format(blid))
+        self.log.info('Password=> {} <= Yes, all this string.'.format(password))
+        self.log.info('Use these credentials in roomba.py')
+
+        result = self.provision_wifi_config(addr, blid, password, fw_ver)
+        if result:
+            self.log.info(
+                'Provisioning information sent. Your robot should connect the desired network in a minute.')
+        else:
+            self.log.error('Provisioning failed.')
+        return result
+
+    def provision_wifi_config(self, addr, blid, password, fw_ver):
+        async def async_provision(myroomba: Roomba):
+            connected = await myroomba.async_connect()
+            if not connected:
+                return False
+
+            try:
+                messages = []
+                messages.append(("wifictl", {"wactivate": False}))
+                messages.append(("wifictl", {"utctime": int(time.time())}))
+                messages.append(("wifictl", {"localtimeoffset": -time.timezone // 60}))
+                if self.timezone is not None:
+                    self.log.info("Using timezone: " + self.timezone)
+                    messages.append(("delta", {"timezone": self.timezone}))
+                if self.sdisc_url is not None:
+                    self.log.info("Using sdiscUrl: " + self.sdisc_url)
+                    messages.append(("wifictl", {"sdiscUrl": self.sdisc_url}))
+                if self.ntphosts is not None:
+                    self.log.info("Using ntphosts: " + self.ntphosts)
+                    messages.append(("wifictl", {"ntphosts": self.ntphosts}))
+                if self.country is not None:
+                    self.log.info("Using country: " + self.country)
+                    messages.append(("delta", {"country": self.country}))
+                if self.cloud_env is not None:
+                    self.log.info("Using cloudEnv: " + self.cloud_env)
+                    messages.append(("delta", {"cloudEnv": self.cloud_env}))
+                if self.robot_name is not None:
+                    self.log.info("Using robot name: " + self.robot_name)
+                    messages.append(("delta", {"name": self.robot_name}))
+
+                wlcfg = {"sec": 7,
+                         "ssid": binascii.hexlify(self.wifi_ssid.encode("UTF-8")).decode()}
+                if fw_ver == 2:
+                    wlcfg["pass"] = self.wifi_password
+                else:
+                    wlcfg["pass"] = binascii.hexlify(self.wifi_password.encode("UTF-8")).decode()
+                messages.append(("wifictl", {"wlcfg": wlcfg}))
+                messages.append(("wifictl", {"chkssid": True}))
+                messages.append(("wifictl", {"wactivate": True}))
+                messages.append(("wifictl", {"get": "netinfo"}))
+                messages.append(("wifictl", {"uap": False}))
+
+                for topic, state in messages:
+                    myroomba.client.publish(topic, json.dumps({"state": state}))
+                    await asyncio.sleep(1)
+
+                return True
+            finally:
+                await myroomba._disconnect()
+
+        myroomba = Roomba(addr, blid=blid, password=password, file=None)
+        return myroomba.loop.run_until_complete(async_provision(myroomba))
+
+
+def main():
+    import argparse
+    loglevel = logging.DEBUG
+    LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
+    LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=LOG_FORMAT, datefmt=LOG_DATE_FORMAT, level=loglevel)
+
+    # -------- Command Line -----------------
+    parser = argparse.ArgumentParser(
+        description='Provision WiFi connection to a robot while connected to its SoftAP network')
+    parser.add_argument(
+        '-R', '--roomba_ip',
+        action='store',
+        type=str,
+        default='192.168.10.1',
+        help='ipaddress of Roomba (default: %(default)s)')
+    parser.add_argument(
+        '-n', '--roomba_name',
+        action='store',
+        type=str,
+        default="", help='Name that the robot shall assume')
+    parser.add_argument(
+        '-s', '--wifi_ssid',
+        action='store',
+        type=str,
+        help='SSID of the WiFi network the robot should connect to')
+    parser.add_argument(
+        '-p', '--wifi_password',
+        action='store',
+        type=str,
+        help='Password of the WiFi network the robot should connect to')
+    parser.add_argument(
+        '-T', '--timezone',
+        action='store',
+        type=str,
+        help='IANA name of the timezone that should be configured on the robot '
+             '(default: read from the host system if possible)')
+    parser.add_argument(
+        '-c', '--country',
+        action='store',
+        type=str,
+        help='Two-letter code of the country the robot is located in '
+             '(for radio regulatory purposed; default: inferred from timezone if possible)')
+    parser.add_argument(
+        '-S', '--sdisc_url',
+        type=str,
+        help='MQTT service discovery URL that the robot shall use after provisioning')
+    parser.add_argument(
+        '-N', '--ntphosts',
+        type=str,
+        help='Space-separated list of NTP servers that the robot shall use')
+    parser.add_argument(
+        '-C', '--cloud_env',
+        type=str,
+        help='Name of the cloud environment that the robot shall use (e.g. "prod")')
+
+    arg = parser.parse_args()
+
+    init_wifi = InitWifi(address=arg.roomba_ip,
+                         wifi_ssid=arg.wifi_ssid,
+                         wifi_password=arg.wifi_password,
+                         country=arg.country,
+                         timezone=arg.timezone,
+                         robot_name=arg.roomba_name,
+                         sdisc_url=arg.sdisc_url,
+                         ntphosts=arg.ntphosts,
+                         cloud_env=arg.cloud_env)
+    init_wifi.init_wifi()
+
+
+if __name__ == '__main__':
+    main()

--- a/roomba/password.py
+++ b/roomba/password.py
@@ -13,8 +13,10 @@ Nick Waterton 22nd Dec 2020: V2.0: Updated for i and S Roomba versions, update t
 from pprint import pformat
 import json
 import logging
+import random
 import socket
 import ssl
+import string
 import sys
 import time
 from ast import literal_eval
@@ -51,13 +53,14 @@ class Password(object):
         #read config file
         Config = configparser.ConfigParser()
         roombas = {}
-        try:
-            Config.read(self.file)
-            self.log.info("reading/writing info from config file {}".format(self.file))
-            roombas = {s:{k:literal_eval(v) if k in self.config_dicts else v for k, v in Config.items(s)} for s in Config.sections()}   
-            #self.log.info('data read from {}: {}'.format(self.file, pformat(roombas)))
-        except Exception as e:
-            self.log.exception(e)
+        if self.file is not None:
+            try:
+                Config.read(self.file)
+                self.log.info("reading/writing info from config file {}".format(self.file))
+                roombas = {s:{k:literal_eval(v) if k in self.config_dicts else v for k, v in Config.items(s)} for s in Config.sections()}
+                #self.log.info('data read from {}: {}'.format(self.file, pformat(roombas)))
+            except Exception as e:
+                self.log.exception(e)
         return roombas
 
     def receive_udp(self):
@@ -156,17 +159,13 @@ class Password(object):
 
             if password is None:
                 self.log.info("Roomba ({}) IP address is: {}".format(robotname, addr))
-                data = self.get_password_from_roomba(addr)
+                password = self.get_password_from_roomba(addr)
                 
-                if len(data) <= 7:
+                if password is None:
                     self.log.error( 'Error getting password for robot {} at ip{}, received {} bytes. '
                                     'Follow the instructions and try again.'.format(robotname, addr, len(data)))
                     continue
-                # Convert password to str
-                password = data[7:]
-                if b'\x00' in password:
-                    password = password[:password.find(b'\x00')] #for i7 - has null termination
-                password = str(password.decode())
+
             self.log.info("blid is: {}".format(blid))
             self.log.info('Password=> {} <= Yes, all this string.'.format(password))
             self.log.info('Use these credentials in roomba.py')
@@ -200,35 +199,101 @@ class Password(object):
         try:
             wrappedSocket.connect((addr, 8883))
             self.log.debug('Connection Successful')
-            wrappedSocket.send(packet)
-            self.log.debug('Waiting for data')
-        
-            while len(data) < 37:
-                data_received = wrappedSocket.recv(1024)
-                data+= data_received
-                if len(data_received) == 0:
-                    self.log.info("socket closed")
-                    break
-                
-            wrappedSocket.close()
-            return data
-            
-        except socket.timeout as e:
-            self.log.error('Connection Timeout Error (for {}): {}'.format(addr, e))
-        except (ConnectionRefusedError, OSError) as e:
-            if e.errno == 111:      #errno.ECONNREFUSED
-                self.log.error('Unable to Connect to roomba at ip {}, make sure nothing else is connected (app?), '
-                               'as only one connection at a time is allowed'.format(addr))
-            elif e.errno == 113:    #errno.No Route to Host
-                self.log.error('Unable to contact roomba on ip {} is the ip correct?'.format(addr))
-            else:
-                self.log.error("Connection Error (for {}): {}".format(addr, e))
-        except Exception as e:
-            self.log.exception(e)
+            try:
+                wrappedSocket.send(packet)
+                self.log.debug('Waiting for data')
 
-        self.log.error('Unable to get password from roomba')
-        return data
-        
+                while len(data) < 37:
+                    data_received = wrappedSocket.recv(1024)
+                    data+= data_received
+                    if len(data_received) == 0:
+                        self.log.info("socket closed")
+                        break
+            finally:
+                wrappedSocket.close()
+        except Exception as e:
+            data = b''
+            if isinstance(e, socket.timeout):
+                self.log.error('Connection Timeout Error (for {}): {}'.format(addr, e))
+            elif isinstance(e, ConnectionRefusedError) or isinstance(e, OSError):
+                if e.errno == 111:      #errno.ECONNREFUSED
+                    self.log.error('Unable to Connect to roomba at ip {}, make sure nothing else is connected (app?), '
+                                   'as only one connection at a time is allowed'.format(addr))
+                elif e.errno == 113:    #errno.No Route to Host
+                    self.log.error('Unable to contact roomba on ip {} is the ip correct?'.format(addr))
+                else:
+                    self.log.error("Connection Error (for {}): {}".format(addr, e))
+            else:
+                self.log.exception(e)
+
+            self.log.error('Unable to get password from roomba')
+            return None
+
+        if len(data) <= 7:
+            return None
+
+        # Convert password to str
+        password = data[7:]
+        if b'\x00' in password:
+            password = password[:password.find(b'\x00')]  # for i7 - has null termination
+        return str(password.decode())
+
+    def generate_new_password(self):
+        alphabet = string.ascii_letters + string.digits
+        password = ":1:{}:".format(int(time.time()))
+        while len(password) < 30:
+            password += random.choice(alphabet)
+        return password
+
+
+    def set_new_password_on_roomba(self, addr, password=None):
+        if password is None:
+            password = self.generate_new_password()
+
+        magic = bytes.fromhex('f023efcc3b2900')
+        packet = magic + password.encode()
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(10)
+        context = ssl.SSLContext()
+        wrappedSocket = context.wrap_socket(sock)
+
+        try:
+            wrappedSocket.connect((addr, 8883))
+            self.log.debug('Connection Successful')
+            try:
+                wrappedSocket.send(packet)
+                deadline = time.time() + 10
+                data = b''
+                while time.time() < deadline:
+                    wrappedSocket.settimeout(max(deadline - time.time(), 0))
+                    data += wrappedSocket.recv(1024)
+                    if magic in data:
+                        break
+                else:
+                    self.log.error('Authentication exchange failed')
+                    return None
+            finally:
+                wrappedSocket.close()
+        except Exception as e:
+            data = b''
+            if isinstance(e, socket.timeout):
+                self.log.error('Connection Timeout Error (for {}): {}'.format(addr, e))
+            elif isinstance(e, ConnectionRefusedError) or isinstance(e, OSError):
+                if e.errno == 111:      #errno.ECONNREFUSED
+                    self.log.error('Unable to Connect to roomba at ip {}, make sure nothing else is connected (app?), '
+                                   'as only one connection at a time is allowed'.format(addr))
+                elif e.errno == 113:    #errno.No Route to Host
+                    self.log.error('Unable to contact roomba on ip {} is the ip correct?'.format(addr))
+                else:
+                    self.log.error("Connection Error (for {}): {}".format(addr, e))
+            else:
+                self.log.exception(e)
+
+            self.log.error('Unable to get password from roomba')
+            return None
+
+        return password
+
     def save_config_file(self, roomba):
         Config = configparser.ConfigParser()
         if roomba:

--- a/roomba/password.py
+++ b/roomba/password.py
@@ -163,7 +163,10 @@ class Password(object):
                                     'Follow the instructions and try again.'.format(robotname, addr, len(data)))
                     continue
                 # Convert password to str
-                password = str(data[7:].decode().rstrip('\x00')) #for i7 - has null termination
+                password = data[7:]
+                if b'\x00' in password:
+                    password = password[:password.find(b'\x00')] #for i7 - has null termination
+                password = str(password.decode())
             self.log.info("blid is: {}".format(blid))
             self.log.info('Password=> {} <= Yes, all this string.'.format(password))
             self.log.info('Use these credentials in roomba.py')

--- a/roomba/roomba.py
+++ b/roomba/roomba.py
@@ -451,7 +451,7 @@ class Roomba(object):
         self.loop.create_task(self.process_command_q())
         self.update = self.loop.create_task(self.periodic_update())
 
-        if not all([self.address, self.blid, self.password]):
+        if not all(field is not None for field in [self.address, self.blid, self.password]):
             if not self.configure_roomba():
                 self.log.critical('Could not configure Roomba')
         else:
@@ -541,7 +541,7 @@ class Roomba(object):
         '''
         Connect to Roomba MQTT server
         '''
-        if not all([self.address, self.blid, self.password]):
+        if not all(field is not None for field in [self.address, self.blid, self.password]):
             self.log.critical("Invalid address, blid, or password! All these "
                               "must be specified!")
             return False

--- a/roomba/roomba_direct.py
+++ b/roomba/roomba_direct.py
@@ -379,7 +379,7 @@ def main():
     group = None
     options = vars(arg) #use args as dict
 
-    if arg.blid is None or arg.password is None:
+    if arg.blid is None and arg.password is None:
         get_passwd = Password(arg.roomba_ip,file=arg.configfile)
         roombas = get_passwd.get_roombas()
     else:


### PR DESCRIPTION
NOTE: This includes changes from #107. You may want to look there first.

Addresses #74

This adds the `initwifi.py` standalone script that allows doing the initial provisioning without the need for the official iRobot Home app.

To use it:
1. Turn on your robot
2. Put it in SoftAP mode by holding down both the Home and Spot buttons for a couple of seconds
3. Connect your computer to the SoftAP network (SSID will be something like `Roomba-XXXX`, with XXXX being the first four characters of the BLID)
4. Run `./initwifi.py`, possibly with arguments to your liking
5. If everything goes well, your robot should connect to your network within a minute (acompanied by a friendly sound)
6. You may then proceed with running `./roomba.py` to configure it as usual

Tested with my Roomba i3.

Acknowledgement: This heavily draws from @kumy's work from the https://github.com/kumy/Roomba-Wifi-Initial-Provisionning repo. They appear to have a R966 with V2 firmware which, judging from their script, requires plaintext WiFi password. I discovered my i3 with V3 firmware to require it hexlified.