### PR TITLE
Resolve SSL context exceptions

### DIFF
--- a/roomba/password.py
+++ b/roomba/password.py
@@ -192,6 +192,8 @@ class Password(object):
         
         #context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
         #context.set_ciphers('DEFAULT@SECLEVEL=1:HIGH:!DH:!aNULL')
         wrappedSocket = context.wrap_socket(sock)
         


### PR DESCRIPTION
## Problem
The current usage of `SSLContext.wrap_socket()` can cause at least 2 exceptions to be thrown (see below). This is due to the transition from `ssl.PROTOCOL_TLS` to `ssl.PROTOCOL_TLS_SERVER`. `ssl.PROTOCOL_TLS` was deprecated in Python 3.10 in favor of the latter, but it adds hostname and certificate checking ([related docs](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT)), which cause problems in this context. 

Given the certificate is not issued for the local IP address we're using to connect and isn't actually issued by a commonly trusted CA, I propose we just bypass these checks. Alternatively, we could update instructions for people to trust the iRobot Issuing CA but that seems complicated when factoring in usage in Home Assistant.

Exceptions:
```
  File "../3.13/lib/python3.13/ssl.py", line 455, in wrap_socket
    return self.sslsocket_class._create(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        sock=sock,
        ^^^^^^^^^^
    ...<5 lines>...
        session=session
        ^^^^^^^^^^^^^^^
    )
    ^
  File "../3.13/lib/python3.13/ssl.py", line 1004, in _create
    raise ValueError("check_hostname requires server_hostname")
```

```
2024-11-15 10:19:17 ERROR [Roomba.Password] Connection Error (for 192.168.112.34): [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1020)
2024-11-15 10:19:17 ERROR [Roomba.Password] Unable to get password from roomba
```

## Additional Info

I'm running python 3.13 but it seems others are having the issue on earlier Python versions in the related issue.

Closes #122 