### PR TITLE
Add 'requests' to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.12.1
 opencv-python>=3.2.0.7
 paho-mqtt>=1.5.1
 Pillow>=6.2.0
+requests>=2.32.3


### PR DESCRIPTION
# What
Add 'requests' library to _requirements.txt_

# Why
While running _passwords.py_ script, the following exception was encountered:
```console
Traceback (most recent call last):
  File "[...]/roomba/Roomba980-Python/roomba/./password.py", line 296, in <module>
    main()
  File "[...]/roomba/Roomba980-Python/roomba/./password.py", line 293, in main
    get_passwd.get_password()
  File "[...]/roomba/Roomba980-Python/roomba/./password.py", line 117, in get_password
    from getcloudpassword import irobotAuth
  File "[...]/roomba/Roomba980-Python/roomba/getcloudpassword.py", line 20, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```

Adding the library to  requirements fixed the issue.
