### PR TITLE
Add error checking, specifically for wrong password usecase

### DIFF
--- a/roomba/getcloudpassword.py
+++ b/roomba/getcloudpassword.py
@@ -104,6 +104,15 @@ class irobotAuth:
                 "oauth_token": response.get('sessionInfo', {}).get('sessionToken', ''),
                 "targetEnv": "mobile"}
         '''
+
+        if response.get('statusCode') != 200:
+            if 'statusCode' in response and 'errorMessage' in response:
+                code = str(response['statusCode'])
+                error_message = str(response['errorMessage'])
+                message = 'Error code %s returned from %s, got: %s' % (code, self.gigyaBase, error_message)
+                print(message, file=sys.stderr)
+                sys.exit(1)
+
         uid = response['UID']
         uidSig = response['UIDSignature']
         sigTime = response['signatureTimestamp']


### PR DESCRIPTION
When providing an incorrect login/password combination, the script just runs into an error checking for the missing UID response field, causing confusion.

Now if you get a 403 it tells you